### PR TITLE
[update] コマンドの引数にユーザネームとパスワードを書かないように変更

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ easy-scraper = "0.1"
 openssl = { version = "0.10", features = ["vendored"] }
 reqwest = { version = "0.10", features = ["cookies"] }
 tokio = { version = "0.2", features = ["full"] }
+rpassword = "5.0.0"

--- a/src/subcommand/config.rs
+++ b/src/subcommand/config.rs
@@ -1,7 +1,8 @@
 use std::io::Write;
 use std::fs::File;
 use std::process;
-use clap::{App, ArgMatches, SubCommand, Arg};
+use clap::{App, ArgMatches, SubCommand};
+use rpassword::read_password;
 use crate::util;
 
 pub const NAME: &str = "config";
@@ -9,25 +10,45 @@ pub const NAME: &str = "config";
 pub fn get_command<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name(&NAME)
         .about("Sets username and password to config_dir/config.toml")
-        .arg(Arg::with_name("USERNAME")
-            .required(true)
-            .index(1))
-        .arg(Arg::with_name("PASSWORD")
-             .required(true)
-             .index(2))
+//        .arg(Arg::with_name("USERNAME")
+//            .required(true)
+//            .index(1))
+//        .arg(Arg::with_name("PASSWORD")
+//             .required(true)
+//             .index(2))
 }
 
-pub fn run(matches: &ArgMatches) {
-    let username = matches.value_of("USERNAME").unwrap();
-    let password = matches.value_of("PASSWORD").unwrap();
+pub fn run(_matches: &ArgMatches) {
+//    let username = matches.value_of("USERNAME").unwrap();
+//    let password = matches.value_of("PASSWORD").unwrap();
+    print!("username:");
+    std::io::stdout().flush().unwrap();
+    let mut username = read_password().unwrap();
+    println!("{}", username);
+    let mut password = String::new();
+    let mut password2 = String::new();
+    loop {
+        print!("password:");
+        std::io::stdout().flush().unwrap();
+        password = read_password().unwrap();
+        println!("{}", std::iter::repeat("*").take(password.len()).collect::<String>());
+        print!("password again:");
+        std::io::stdout().flush().unwrap();
+        password2 = read_password().unwrap();
+        if password == password2 {
+            break;
+        }
+        println!("password is wrong!!\n");
+    }
+
     let _ = util::load_config(false); // 初回時config.toml作成
     let mut userdata = util::load_userdata();
     let userdata_path = dirs::config_dir().unwrap_or_else(|| {
             util::print_error("config directory is not defined");
             process::exit(1)
         }).to_string_lossy().to_string() + "/acc/userdata.toml";
-    userdata.username = Some(username.to_string());
-    userdata.password = Some(password.to_string());
+    userdata.username = Some(username);
+    userdata.password = Some(password);
     let mut userdata_file = File::create(userdata_path).unwrap();
     let content = toml::to_string(&userdata).unwrap();
     userdata_file.write_all(content.as_bytes()).unwrap_or_else(|_| {


### PR DESCRIPTION
acc config コマンドの引数にユーザネームとパスワードを指定していたのをなくしコマンド実行時に入力するように変更
﻿
