### PR TITLE
[fix] テストケースに空文字列が含まれている場合に正常に動作しない問題を解決

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ openssl = { version = "0.10", features = ["vendored"] }
 reqwest = { version = "0.10", features = ["cookies"] }
 tokio = { version = "0.2", features = ["full"] }
 rpassword = "5.0.0"
+regex = "1"

--- a/src/subcommand/config.rs
+++ b/src/subcommand/config.rs
@@ -10,20 +10,12 @@ pub const NAME: &str = "config";
 pub fn get_command<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name(&NAME)
         .about("Sets username and password to config_dir/config.toml")
-//        .arg(Arg::with_name("USERNAME")
-//            .required(true)
-//            .index(1))
-//        .arg(Arg::with_name("PASSWORD")
-//             .required(true)
-//             .index(2))
 }
 
 pub fn run(_matches: &ArgMatches) {
-//    let username = matches.value_of("USERNAME").unwrap();
-//    let password = matches.value_of("PASSWORD").unwrap();
     print!("username:");
     std::io::stdout().flush().unwrap();
-    let mut username = read_password().unwrap();
+    let username = read_password().unwrap();
     println!("{}", username);
     let mut password = String::new();
     let mut password2 = String::new();

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,7 +20,8 @@ print_wrong_answer = true
 pub const LOGIN_URL: &str = "https://atcoder.jp/login";
 pub const TASK_URL: &str = "https://atcoder.jp/contests/<CONTEST>/tasks/<CONTEST_TASK>_<TASK>";
 pub const SUBMIT_URL: &str = "https://atcoder.jp/contests/<CONTEST>/submit";
-pub const TESTCASE_PATTERN: &str = r#"<span class="lang-ja"><h3></h3><pre>{{io}}</pre></span>"#;
+//pub const TESTCASE_PATTERN: &str = r#"<span class="lang-ja"><h3></h3><pre>{{io}}</pre></span>"#;
+pub const TESTCASE_PATTERN: &str = r#"<span class="lang-ja"><div class="part"><section>{{io:*}}</section></div></span>"#;
 pub const CSRF_TOKEN_PATTERN: &str = r#"<input type="hidden" name="csrf_token" value={{token}} />"#;
 
 pub fn print_error<S: Into<String>>(error_message: S) {


### PR DESCRIPTION
以下の変更によってから文字に対応した
- util.rs内のスクレイピングのパターンの変更
- 既存のパターンより親をスクレイピングし，その文字列から正規表現によってテストケースを抜き出すことで空文字列に対応
