### PR TITLE
[update] acc init の引数に最初に作成するファイル数を指定するものを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ acc config <USERNAME> <PASSWORD>
 $ acc init [OPTION] <DIR_NAME>
 
 ex )
-$ acc init -e py -l 3023 abc160
+$ acc init -e py -l 4006 abc160
 ```
 
 基本的にディレクトリ名をコンテスト名として使用するため，ディレクトリと異なるコンテストディレクトリを作成したい場合は，コマンド実行後にコンテストディレクトリ内のconfig.tomlを編集する必要がある．
@@ -48,10 +48,9 @@ $ acc init -e py -l 3023 abc160
 | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
 | -e <br>--extension                         | 最初に作成されるファイルの拡張子を指定する, \<config\_dir\>/acc/template.\<extension\>があればテンプレートとして使用される |
 | -l <br> --lang                             | AtCoderで提出するときの言語を指定する(詳細は後述)                                                                          |
+| -t <br> --total                             | 最初に作成するファイルの数を指定する                                                                         |
 
 -l --lang で指定する値の詳細
-
-1. 新システム
 
 | 使用する言語 | 指定する値 |
 | :---: | :---: |
@@ -123,67 +122,6 @@ $ acc init -e py -l 3023 abc160
 | Sed (4.4) | 4066 |
 | Vim (8.2.0460) | 4067 |
 
-2. 旧システム
-
-|          使用する言語           | 指定する値 |
-| :-----------------------------: | :--------: |
-|        C++14 (GCC 5.4.1)        |    3003    |
-|     Bash (GNU bash v4.3.11)     |    3001    |
-|          C (GCC 5.4.1)          |    3002    |
-|         C (Clang 3.8.0)         |    3004    |
-|       C++14 (Clang 3.8.0)       |    3005    |
-|        C# (Mono 4.6.2.0)        |    3006    |
-|         Clojure (1.8.0)         |    3007    |
-|    Common Lisp (SBCL 1.1.14)    |    3008    |
-|       D (DMD64 v2.070.1)        |    3009    |
-|         D (LDC 0.17.0)          |    3010    |
-|          D (GDC 4.9.4)          |    3011    |
-|    Fortran (gfortran v4.8.4)    |    3012    |
-|            Go (1.6)             |    3013    |
-|      Haskell (GHC 7.10.3)       |    3014    |
-|      Java7 (OpenJDK 1.7.0)      |    3015    |
-|      Java8 (OpenJDK 1.8.0)      |    3016    |
-|   JavaScript (node.js v5.12)    |    3017    |
-|         OCaml (4.02.3)          |    3018    |
-|       Pascal (FPC 2.6.2)        |    3019    |
-|         Perl (v5.18.2)          |    3020    |
-|          PHP (5.6.30)           |    3021    |
-|         Python2 (2.7.6)         |    3022    |
-|         Python3 (3.4.3)         |    3023    |
-|          Ruby (2.3.3)           |    3024    |
-|         Scala (2.11.7)          |    3025    |
-|     Scheme (Gauche 0.9.3.3)     |    3026    |
-|           Text (cat)            |    3027    |
-|    Visual Basic (Mono 4.0.1)    |    3028    |
-|         C++ (GCC 5.4.1)         |    3029    |
-|        C++ (Clang 3.8.0)        |    3030    |
-|     Objective-C (GCC 5.3.0)     |    3501    |
-|    Objective-C (Clang3.8.0)     |    3502    |
-|    Swift (swift-2.2-RELEASE)    |    3503    |
-|          Rust (1.15.1)          |    3504    |
-|       Sed (GNU sed 4.2.2)       |    3505    |
-|        Awk (mawk 1.3.3)         |    3506    |
-|     Brainfuck (bf 20041219)     |    3507    |
-|  Standard ML (MLton 20100608)   |    3508    |
-|          PyPy2 (5.6.0)          |    3509    |
-|          PyPy3 (2.4.0)          |    3510    |
-|        Crystal (0.20.5)         |    3511    |
-|          F# (Mono 4.0)          |    3512    |
-|        Unlambda (0.1.3)         |    3513    |
-|           Lua (5.3.2)           |    3514    |
-|         LuaJIT (2.0.4)          |    3515    |
-|       MoonScript (0.5.0)        |    3516    |
-|         Ceylon (1.2.1)          |    3517    |
-|          Julia (0.5.0)          |    3518    |
-|         Octave (4.0.2)          |    3519    |
-|          Nim (0.13.0)           |    3520    |
-|       TypeScript (2.1.6)        |    3521    |
-|   Perl6 (rakudo-star 2016.01)   |    3522    |
-|         Kotlin (1.0.0)          |    3523    |
-|          PHP7 (7.0.15)          |    3524    |
-| COBOL - Fixed (OpenCOBOL 1.1.0) |    3525    |
-| COBOL - Free (OpenCOBOL 1.1.0)  |    3526    |
-
 ---
 
 ### テスト
@@ -240,7 +178,7 @@ $ acc submit A
 ```toml
 total_task = 6
 extension = "cpp"
-language_id = 3003
+language_id = 4003
 
 [test]
 compiler = "g++"
@@ -255,7 +193,7 @@ print_wrong_answer = true
 ```toml
 total_task = 6
 extension = "py"
-language_id = 3023
+language_id = 4006
 
 [test]
 command = "python3"

--- a/src/subcommand/init.rs
+++ b/src/subcommand/init.rs
@@ -4,6 +4,7 @@ use std::io::prelude::*;
 use std::path::Path;
 use clap::{App, ArgMatches, SubCommand, Arg};
 use crate::util;
+use crate::colortext;
 
 pub const NAME: &str = "init";
 
@@ -25,6 +26,12 @@ pub fn get_command<'a, 'b>() -> App<'a, 'b> {
             .help("Sets a language id")
             .takes_value(true)
             .value_name("LANGUAGE_ID"))
+        .arg(Arg::with_name("total_task")
+            .short("t")
+            .long("total")
+            .help("Sets a number of tasks")
+            .takes_value(true)
+            .value_name("TOTAL"))
 }
 
 
@@ -32,6 +39,7 @@ pub fn run(matches: &ArgMatches) {
     let dir_name = matches.value_of("DIR_NAME").unwrap();
     let extension = matches.value_of("extension");
     let language_id = matches.value_of("language_id");
+    let total_task = matches.value_of("total_task");
     let path = env::current_dir().unwrap();
     let path = path.to_str().unwrap();
     let config = util::load_config(false);
@@ -74,7 +82,14 @@ pub fn run(matches: &ArgMatches) {
         config.extension
     };
     if let Some(extension) = extension {
-        let total_file = config.total_task.unwrap();
+        let total_file = if total_task.is_some() {
+            total_task.unwrap().parse().unwrap_or_default()
+        } else {
+            config.total_task.unwrap()
+        };
+        if total_file <= 0 {
+            println!("{}: TOTAL_TASK can not set", colortext::WARNING);
+        }
         let files = (b'A'..=b'Z').take(total_file as usize)
             .map(|c| c as char)
             .map(|file| [file.to_string(), extension.clone()].join("."))


### PR DESCRIPTION
acc init <CONTEST_NAME> -t or --total <TOTAL_TASK>とすることで最初に作成するファイル数を指定できるように変更
指定されない場合はグローバルの設定を適用する
