### PR TITLE
[fix] acc loginの改行とデフォルトの言語IDを修正

### DIFF
--- a/src/subcommand/login.rs
+++ b/src/subcommand/login.rs
@@ -20,12 +20,14 @@ pub fn run(_matches: &ArgMatches) {
     let mut password = String::new();
     let mut password2 = String::new();
     loop {
-        println!("password:");
+        print!("password:");
         std::io::stdout().flush().unwrap();
         password = read_password().unwrap();
-        println!("password again:");
+        print!("\n");
+        print!("password again:");
         std::io::stdout().flush().unwrap();
         password2 = read_password().unwrap();
+        print!("\n");
         if password == password2 {
             break;
         }

--- a/src/subcommand/login.rs
+++ b/src/subcommand/login.rs
@@ -20,10 +20,10 @@ pub fn run(_matches: &ArgMatches) {
     let mut password = String::new();
     let mut password2 = String::new();
     loop {
-        print!("password:");
+        println!("password:");
         std::io::stdout().flush().unwrap();
         password = read_password().unwrap();
-        print!("password again:");
+        println!("password again:");
         std::io::stdout().flush().unwrap();
         password2 = read_password().unwrap();
         if password == password2 {

--- a/src/subcommand/submit.rs
+++ b/src/subcommand/submit.rs
@@ -68,6 +68,6 @@ pub fn run(matches: &ArgMatches) {
             util::print_error("failed to submit source code");
         }
     } else {
-        util::print_error("failed to submit source code");
+        util::print_error("failed to get submit page");
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,7 @@ use std::{env, fs, process};
 
 const DEFAULT_CONFIG: &str = r#"total_task = 6
 extension = "cpp"
-language_id = 3003
+language_id = 4003
 
 [test]
 compiler = "g++"


### PR DESCRIPTION
- [fix] acc loginの改行とデフォルトの言語を修正
- [fix] デフォルトの言語IDを3003から4003に変更
- [update] acc submit失敗時のメッセージを分割

close #14 
close #15 
