### PR TITLE
言語周りのコンフィグの変更とそれに伴う各コマンドの動作の変更

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acc"
-version = "1.1.3"
+version = "1.2.5"
 authors = ["Takachiha <akimoto14301@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # acc
-AtCoderのテストや提出するやつ
+AtCoderのテストや提出をおこなうコマンド
 
 ## ディレクトリ構成
 ```
@@ -38,7 +38,7 @@ $ acc login
 $ acc init [OPTION] <DIR_NAME>
 
 ex )
-$ acc init -e py -l 4006 abc160
+$ acc init abc160 -l python
 ```
 
 基本的にディレクトリ名をコンテスト名として使用するため，ディレクトリと異なるコンテストディレクトリを作成したい場合は，コマンド実行後にコンテストディレクトリ内のconfig.tomlを編集する必要がある．
@@ -47,11 +47,73 @@ $ acc init -e py -l 4006 abc160
 
 | &nbsp;&nbsp;&nbsp;OPTION&nbsp;&nbsp;&nbsp; |                                                            説明                                                            |
 | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
-| -e <br>--extension                         | 最初に作成されるファイルの拡張子を指定する, \<config\_dir\>/acc/template.\<extension\>があればテンプレートとして使用される |
-| -l <br> --lang                             | AtCoderで提出するときの言語を指定する(詳細は後述)                                                                          |
+| -l <br> --lang                             | AtCoderで提出するときの言語を指定する(自分で設定したものを指定する必要)                                                                          |
 | -t <br> --total                             | 最初に作成するファイルの数を指定する                                                                         |
 
--l --lang で指定する値の詳細
+---
+
+### テスト
+ソースコードのテストを行う.
+
+```bash
+$ acc test <TASK>
+
+ex )
+$ acc test A
+```
+
+- コンテストディレクトリ内で実行を行う必要がある．
+- 初回実行時AtCoderからテストを取得し，プロジェクト内にtestcase/\<TASK\>.tomlとして保存する．
+- テストケースを追加したい場合は，testcaseディレクトリ内のファイルを編集することで対応できる
+
+---
+
+### ファイル監視＆テスト
+指定されたタスクのファイル監視をし，変更されたらテストを行う.
+
+```bash
+$ acc watch <TASK>
+
+ex )
+$ acc watch A
+```
+
+- テスト関連の仕様はtestと同じ
+
+---
+
+### 提出
+ソースコードの提出を行う．
+
+```bash
+$ acc submit <TASK>
+
+ex )
+$ acc submit A
+```
+---
+
+## 設定
+### 詳細
+<language\_name>はTOMLの使用に従う範囲で任意に設定可能
+
+|           項目            |             型              |                              説明                                                       | 備考 |
+| :------------------------ | :-------------------------- | --------------------------------------------------------------------------------------- |:----:|
+| contest                   | String                      | コンテスト名(コンテストプロジェクト内の設定)                                            | 必須 |
+| contest\_task\_name       | String                      | URLのタスク部分のコンテスト名(contestと異なるとき指定)                                  |      |
+| selected\_language        | String                      | 使用する言語を指定                                                                      |      |
+| languages.<language\_name>.extension                 | String                      | ファイルの拡張子を指定                                       | 必須 |
+| languages.<language\_name>.language\_id              | Integer(符号なし１６ビット) | AtCoderの言語指定                                            | 必須 |
+| languages.<language\_name>.test.compiler             | String                      | テスト時に使用するコンパイラを指定                           |      |
+| languages.<language\_name>.test.compile\_arg         | String                      | コンパイル時のarg指定                                        |      |
+| languages.<language\_name>.test.command              | String                      | 実行するコマンドを指定                                       | 必須 |
+| languages.<language\_name>.test.command\_arg         | String                      | コマンドを実行するときのarg指定                              |      |
+| languages.<language\_name>.test.tle\_time            | Integer(符号なし１６ビット) | TLEの時間指定[ms]                                            | 必須 |
+| languages.<language\_name>.test.print\_wrong\_answer | Boolean                     | WAのときの出力                                               | 必須 |
+
+---
+
+### 言語ID一覧
 
 | 使用する言語 | 指定する値 |
 | :---: | :---: |
@@ -123,96 +185,36 @@ $ acc init -e py -l 4006 abc160
 | Sed (4.4) | 4066 |
 | Vim (8.2.0460) | 4067 |
 
----
-
-### テスト
-ソースコードのテストを行う.
-
-```bash
-$ acc test <TASK>
-
-ex )
-$ acc test A
-```
-
-- コンテストディレクトリ内で実行を行う必要がある．
-- 初回実行時AtCoderからテストを取得し，プロジェクト内にtestcase/\<TASK\>.tomlとして保存する．
-- テストケースを追加したい場合は，testcaseディレクトリ内のファイルを編集することで対応できる
-
----
-
-### ファイル監視＆テスト
-指定されたタスクのファイル監視をし，変更されたらテストを行う.
-
-```bash
-$ acc watch <TASK>
-
-ex )
-$ acc watch A
-```
-
-- テスト関連の仕様はtestと同じ
-
----
-
-### 提出
-ソースコードの提出を行う．
-
-```bash
-$ acc submit <TASK>
-
-ex )
-$ acc submit A
-```
----
-
-## 設定
-### 詳細
-
-|           項目            |             型              |                              説明                              |
-| :------------------------ | :-------------------------- | -------------------------------------------------------------- |
-| contest                   | String                      | コンテスト名(コンテストプロジェクト内の設定)                   |
-| contest\_task\_name         | String                      | URLのタスク部分のコンテスト名(contestと異なるとき指定)        |
-| total\_task               | Integer(符号なし8ビット)    | acc init時に作成されるファイル数を指定(拡張子設定が無いと無効) |
-| extension                 | String                      | ファイルの拡張子を指定                                         |
-| language\_id              | Integer(符号なし１６ビット) | AtCoderの言語指定                                              |
-| test.compiler             | String                      | テスト時に使用するコンパイラを指定                             |
-| test.compile\_arg         | String                      | コンパイル時のarg指定                                          |
-| test.command              | String                      | 実行するコマンドを指定                                         |
-| test.command\_arg         | String                      | コマンドを実行するときのarg指定                                |
-| test.tle\_time            | Integer(符号なし１６ビット) | TLEの時間指定[ms]                                              |
-| test.print\_wrong\_answer | Boolean                     | WAのときの出力                                                 |
-
----
 
 ### 設定例
-\<config\_dir\>/acc/config.tomlの例
+\<config\_dir\>/acc/config.tomlの設定例
 \<TASK\>はacc testで指定したものを代入するためのもの
 #### C++
 
 ```toml
-total_task = 6
-extension = "cpp"
-language_id = 4003
+contest = "config"
+selected_language = "cpp_gcc"
 
-[test]
+[languages.cpp_gcc]
+extension = "cpp"
+language_id = "4003"
+
+[languages.cpp_gcc.test]
 compiler = "g++"
-compile_arg = "<TASK>.cpp -o <TASK>"
+compile_arg = "-std=gnu++17 -o <TASK> <TASK>.cpp"
 command = "./<TASK>"
 tle_time = 3000
 print_wrong_answer = true
-```
 
-#### Python3
-
-```toml
-total_task = 6
+[languages.python]
 extension = "py"
-language_id = 4006
+language_id = "4006"
 
-[test]
+[languages.python.test]
 command = "python3"
 command_arg = "<TASK>.py"
 tle_time = 3000
 print_wrong_answer = true
+
 ```
+

--- a/src/acc_client.rs
+++ b/src/acc_client.rs
@@ -4,7 +4,7 @@ use easy_scraper::Pattern;
 use reqwest::{header, Client, Response};
 use std::process;
 
-pub const USER_AGENT: &str = "acc/1.1.3";
+pub const USER_AGENT: &str = "acc/1.2.5";
 pub const LOGIN_URL: &str = "https://atcoder.jp/login?continue=https%3A%2F%2Fatcoder.jp%2Fcontests%2Fpractice%2Fsubmissions%2Fme";
 pub const PRACTICE_URL: &str = "https://atcoder.jp/contests/practice/submissions/me";
 pub const TASK_URL: &str = "https://atcoder.jp/contests/<CONTEST>/tasks/<CONTEST_TASK>_<TASK>";

--- a/src/config/language.rs
+++ b/src/config/language.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+use crate::config::Test;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Language {
+    pub extension: String,
+    pub language_id: String,
+    pub test: Test,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,20 +1,17 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub use test::Test;
+pub use language::Language;
 
 pub mod state;
 pub mod test;
+pub mod language;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
-    pub contest: Option<String>,
+    pub contest: String,
     pub contest_task_name: Option<String>,
-    pub total_task: Option<u8>,
-    pub extension: Option<String>,
-    pub language_id: Option<u16>,
-    pub test: Test,
-}
-
-pub trait Overridable {
-    fn override_by_default(&mut self);
+    pub selected_language: Option<String>,
+    pub languages: HashMap<String, Language>,
 }

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -1,4 +1,3 @@
-use crate::config::Overridable;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -7,17 +6,6 @@ pub struct Test {
     pub compile_arg: Option<String>,
     pub command: String,
     pub command_arg: Option<String>,
-    pub tle_time: Option<u16>,
-    pub print_wrong_answer: Option<bool>,
-}
-
-impl Overridable for Test {
-    fn override_by_default(&mut self) {
-        if self.tle_time.is_none() {
-            self.tle_time = Some(3000);
-        }
-        if self.print_wrong_answer.is_none() {
-            self.print_wrong_answer = Some(true);
-        }
-    }
+    pub tle_time: u16,
+    pub print_wrong_answer: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use clap::App;
 
 fn main() {
     let matches = App::new("acc")
-        .version("v1.1.3")
+        .version("v1.2.5")
         .subcommand(subcommand::init::get_command())
         .subcommand(subcommand::submit::get_command())
         .subcommand(subcommand::test::get_command())

--- a/src/subcommand/submit.rs
+++ b/src/subcommand/submit.rs
@@ -11,31 +11,37 @@ pub fn get_command<'a, 'b>() -> App<'a, 'b> {
         .arg(Arg::with_name("TASK_NAME").required(true).index(1))
 }
 
-fn get_source(file_name: &str) -> String {
+fn get_source(file_name: &str) -> Option<String> {
     let mut path = env::current_dir().unwrap();
     path.push(file_name);
+    if !path.exists() {
+        return None;
+    }
     let path = path.to_str().unwrap();
-    util::read_file(path)
+    Some(util::read_file(path))
 }
 
 pub fn run(matches: &ArgMatches) {
     let task_name = matches.value_of("TASK_NAME").unwrap();
     let config = util::load_config(true);
+    let contest_name = config.contest;
     let contest_task_name = config.contest_task_name;
-    let extension = config.extension.unwrap_or_else(|| {
-        util::print_error("extension in config.toml is not defined");
-        process::exit(1);
-    });
-    let language_id = config.language_id.unwrap_or_else(|| {
-        util::print_error("language_id in config.toml is not defined");
-        process::exit(1);
-    });
-
-    let contest_name = config.contest.unwrap_or_else(|| {
-        util::print_error("contest_name in local config.toml is not defined");
-        process::exit(1);
-    });
+    let language = if util::has_extension(task_name) {
+        let extension = task_name.clone().split_terminator(".").last().unwrap();
+        util::select_language(config.languages, &extension).unwrap()
+    } else {
+        let language_name = config.selected_language.unwrap_or_else(|| {
+            util::print_error("selected_language setting or file extension is needed");
+            process::exit(1);
+        });
+        config.languages.get(&language_name).unwrap_or_else(|| {
+            util::print_error(format!("\"{}\" is not found in languages", language_name));
+            process::exit(1);
+        }).clone()
+    };
+    let extension = language.extension;
     let file_name = [task_name, &extension].join(".");
+    let language_id = language.language_id;
 
     let client = AccClient::new(true);
     let url = acc_client::SUBMIT_URL.to_string();
@@ -45,8 +51,11 @@ pub fn run(matches: &ArgMatches) {
     } else {
         contest_name.clone()
     };
+    let source = get_source(&file_name).unwrap_or_else(|| {
+        util::print_error(format!("{} is not found", &file_name));
+        process::exit(1);
+    });
     let screen_name = format!("{}_{}", &task, task_name.to_lowercase());
-    let source = get_source(&file_name);
     let token = client.get_csrf_token().unwrap_or_else(|| {
         util::print_error("Require to run \"acc login\"");
         process::exit(1);

--- a/src/subcommand/submit.rs
+++ b/src/subcommand/submit.rs
@@ -40,7 +40,12 @@ pub fn run(matches: &ArgMatches) {
         }).clone()
     };
     let extension = language.extension;
-    let file_name = [task_name, &extension].join(".");
+    let (file_name, task_name) = if util::has_extension(task_name) {
+        let extension = String::from(".") + &extension;
+        (task_name.to_string(), task_name.strip_suffix(&extension).unwrap())
+    } else {
+        ([task_name, &extension].join("."), task_name)
+    };
     let language_id = language.language_id;
 
     let client = AccClient::new(true);

--- a/src/subcommand/test.rs
+++ b/src/subcommand/test.rs
@@ -233,7 +233,7 @@ pub fn get_testcases(
 pub fn test(task_name: &str, inputs: &Vec<String>, outputs: &Vec<String>, config: &Test) {
     let mut all_result = Status::AC;
     let mut count = 0;
-    let needs_print = config.print_wrong_answer.unwrap();
+    let needs_print = config.print_wrong_answer;
     if config.compiler.is_some() {
         let is_completed = compile(&config, task_name);
         if !is_completed {
@@ -245,7 +245,7 @@ pub fn test(task_name: &str, inputs: &Vec<String>, outputs: &Vec<String>, config
         count += 1;
         print!("- testcase {} ... ", count);
 
-        let tle_time = config.tle_time.unwrap_or(3000);
+        let tle_time = config.tle_time;
         let (caused_runtime_error, result) = execute(config, task_name, input, tle_time);
         if caused_runtime_error {
             all_result = all_result.max(Status::RE);
@@ -280,11 +280,21 @@ pub fn run(matches: &ArgMatches) {
     let task_name = matches.value_of("TASK_NAME").unwrap();
     let config = util::load_config(true);
     let contest_task_name = config.contest_task_name;
-    let contest_name = config.contest.unwrap_or_else(|| {
-        util::print_error("contest_name in local config.toml is not defined");
-        process::exit(1);
-    });
-    let config = config.test;
+    let contest_name = config.contest;
+    let language = if util::has_extension(task_name) {
+        let extension = task_name.clone().split_terminator(".").last().unwrap();
+        util::select_language(config.languages, &extension).unwrap()
+    } else {
+        let language_name = config.selected_language.unwrap_or_else(|| {
+            util::print_error("selected_language setting or file extension is needed");
+            process::exit(1);
+        });
+        config.languages.get(&language_name).unwrap_or_else(|| {
+            util::print_error(format!("\"{}\" is not found in languages", language_name));
+            process::exit(1);
+        }).clone()
+    };
+    let config = language.test;
     let (inputs, outputs) = get_testcases(&contest_name, contest_task_name, &task_name);
     test(&task_name, &inputs, &outputs, &config);
 }

--- a/src/subcommand/test.rs
+++ b/src/subcommand/test.rs
@@ -99,7 +99,10 @@ fn compile(config: &Test, task_name: &str) -> bool {
     let output = Command::new(compiler)
         .args(args)
         .output()
-        .expect("failed to execute process");
+        .unwrap_or_else(|_| {
+            util::print_error("fail to execute compile command");
+            process::exit(1);
+        });
     let status = output.status;
     if !status.success() {
         let output = String::from_utf8_lossy(&output.stderr);
@@ -295,6 +298,12 @@ pub fn run(matches: &ArgMatches) {
         }).clone()
     };
     let config = language.test;
+    let task_name = if util::has_extension(task_name) {
+        let extension = String::from(".") + &language.extension;
+        task_name.strip_suffix(&extension).unwrap()
+    } else {
+        task_name
+    };
     let (inputs, outputs) = get_testcases(&contest_name, contest_task_name, &task_name);
     test(&task_name, &inputs, &outputs, &config);
 }

--- a/src/subcommand/watch.rs
+++ b/src/subcommand/watch.rs
@@ -35,7 +35,12 @@ pub fn run(matches: &ArgMatches) {
     };
     let config = language.test;
     let extension = language.extension;
-
+    let task_name = if util::has_extension(task_name) {
+        let extension = String::from(".") + &extension;
+        task_name.strip_suffix(&extension).unwrap()
+    } else {
+        task_name
+    };
     let (inputs, outputs) = test::get_testcases(&contest_name, contest_task_name, &task_name);
 
     let mut path = env::current_dir().unwrap();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
 use crate::colortext;
 use crate::config::state::{Cookie, State};
 use crate::config::{Config, Language};
-use std::io::prelude::*;
 use std::collections::HashMap;
 use std::{env, fs, process};
 use termion::event::Key;


### PR DESCRIPTION
- [update] コンフィグの言語設定を元から変更
- [update] test, submit, watchで拡張子を伴うファイル指定を行えるように変更
- [fix] コンパイル失敗時にパニックするのを修正
- [update] バージョンを1.2.5に変更
- [update] READMEを現時点のバージョンにあったものに変更

close #27