### PR TITLE
[update] test, submit, watchの引数にコンテスト情報を指定できるよう変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,14 @@ $ acc init abc160 -l python
 ソースコードのテストを行う.
 
 ```bash
-$ acc test <TASK>
+$ acc test <CONTEST_INFO>...
 
 ex.)
-$ acc test A
+$ acc test 1
+or
+$ acc test practice practice_1.cpp
+or
+$ acc test practice practice_1 p1
 ```
 
 - コンテストディレクトリ内で実行を行う必要がある．
@@ -72,10 +76,14 @@ $ acc test A
 指定されたタスクのファイル監視をし，変更されたらテストを行う.
 
 ```bash
-$ acc watch <TASK>
+$ acc watch <CONTEST_INFO>...
 
 ex.)
-$ acc watch A
+$ acc watch 1
+or
+$ acc watch practice practice_1.cpp
+or
+$ acc watch practice practice_1 p1
 ```
 
 - テスト関連の仕様はtestと同じ
@@ -86,10 +94,14 @@ $ acc watch A
 ソースコードの提出を行う．
 
 ```bash
-$ acc submit <TASK>
+$ acc submit <CONTEST_INFO>...
 
 ex.)
-$ acc submit A
+$ acc submit 1
+or
+$ acc submit practice practice_1.cpp
+or
+$ acc submit practice practice_1 p1
 ```
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ acc login
 ```bash
 $ acc init [OPTION] <DIR_NAME>
 
-ex )
+ex.)
 $ acc init abc160 -l python
 ```
 
@@ -58,7 +58,7 @@ $ acc init abc160 -l python
 ```bash
 $ acc test <TASK>
 
-ex )
+ex.)
 $ acc test A
 ```
 
@@ -74,7 +74,7 @@ $ acc test A
 ```bash
 $ acc watch <TASK>
 
-ex )
+ex.)
 $ acc watch A
 ```
 
@@ -88,7 +88,7 @@ $ acc watch A
 ```bash
 $ acc submit <TASK>
 
-ex )
+ex.)
 $ acc submit A
 ```
 ---

--- a/src/acc_client.rs
+++ b/src/acc_client.rs
@@ -7,9 +7,11 @@ use std::process;
 pub const USER_AGENT: &str = "acc/1.2.5";
 pub const LOGIN_URL: &str = "https://atcoder.jp/login?continue=https%3A%2F%2Fatcoder.jp%2Fcontests%2Fpractice%2Fsubmissions%2Fme";
 pub const PRACTICE_URL: &str = "https://atcoder.jp/contests/practice/submissions/me";
-pub const TASK_URL: &str = "https://atcoder.jp/contests/<CONTEST>/tasks/<CONTEST_TASK>_<TASK>";
+pub const TASK_URL: &str = "https://atcoder.jp/contests/<CONTEST>/tasks/<CONTEST_TASK>";
 pub const SUBMIT_URL: &str = "https://atcoder.jp/contests/<CONTEST>/submit";
 pub const SUBMISSIONS_URL: &str = "https://atcoder.jp/contests/<CONTEST>/submissions/me";
+//pub const TESTCASE_PATTERN: &str =
+//    r#"<span class="lang-ja"><div class="part"><section>{{io:*}}</section></div></span>"#;
 pub const TESTCASE_PATTERN: &str =
     r#"<span class="lang-ja"><div class="part"><section>{{io:*}}</section></div></span>"#;
 pub const CSRF_TOKEN_PATTERN: &str = r#"<input type="hidden" name="csrf_token" value={{token}} />"#;

--- a/src/acc_client.rs
+++ b/src/acc_client.rs
@@ -10,8 +10,6 @@ pub const PRACTICE_URL: &str = "https://atcoder.jp/contests/practice/submissions
 pub const TASK_URL: &str = "https://atcoder.jp/contests/<CONTEST>/tasks/<CONTEST_TASK>";
 pub const SUBMIT_URL: &str = "https://atcoder.jp/contests/<CONTEST>/submit";
 pub const SUBMISSIONS_URL: &str = "https://atcoder.jp/contests/<CONTEST>/submissions/me";
-//pub const TESTCASE_PATTERN: &str =
-//    r#"<span class="lang-ja"><div class="part"><section>{{io:*}}</section></div></span>"#;
 pub const TESTCASE_PATTERN: &str =
     r#"<span class="lang-ja"><div class="part"><section>{{io:*}}</section></div></span>"#;
 pub const CSRF_TOKEN_PATTERN: &str = r#"<input type="hidden" name="csrf_token" value={{token}} />"#;

--- a/src/colortext.rs
+++ b/src/colortext.rs
@@ -1,20 +1,34 @@
-pub const INFO: &str = "\x1b[38;5;14minfo\x1b[0m";
-pub const ERROR: &str = "\x1b[38;5;9merror\x1b[0m";
-pub const WARNING: &str = "\x1b[38;5;11mwarning\x1b[0m";
-pub const AC: &str = "\x1b[38;5;15m\x1b[48;5;34m AC \x1b[0m";
-pub const WA: &str = "\x1b[38;5;15m\x1b[48;5;214m WA \x1b[0m";
-pub const RE: &str = "\x1b[38;5;15m\x1b[48;5;214m RE \x1b[0m";
-pub const CE: &str = "\x1b[38;5;15m\x1b[48;5;214m CE \x1b[0m";
-pub const TLE: &str = "\x1b[38;5;15m\x1b[48;5;214m TLE \x1b[0m";
+use termion::color::{self, Bg, Fg};
+use termion::style;
 
-pub fn get_green(text: &str) -> String {
-    format!("\x1b[38;5;15m\x1b[48;5;34m {} \x1b[0m", text).to_string()
+pub fn info() -> String {
+    format!("{}info{}", Fg(color::Rgb(0, 255, 255)), style::Reset).to_string()
 }
 
-pub fn get_yellow(text: &str) -> String {
-    format!("\x1b[38;5;15m\x1b[48;5;214m {} \x1b[0m", text).to_string()
+pub fn error() -> String {
+    format!("{}error{}", Fg(color::Rgb(255, 0, 0)), style::Reset).to_string()
 }
 
-pub fn get_gray(text: &str) -> String {
-    format!("\x1b[38;5;15m\x1b[48;5;248m {} \x1b[0m", text).to_string()
+pub fn warning() -> String {
+    format!("{}warning{}", Fg(color::Rgb(255, 255, 0)), style::Reset).to_string()
+}
+
+pub fn ac() -> String {
+    format!("{}{} AC {}", Fg(color::Rgb(255, 255, 255)), Bg(color::Rgb(92, 184, 92)), style::Reset).to_string()
+}
+
+pub fn wa() -> String {
+    format!("{}{} WA {}", Fg(color::Rgb(255, 255, 255)), Bg(color::Rgb(240, 173, 78)), style::Reset).to_string()
+}
+
+pub fn re() -> String {
+    format!("{}{} RE {}", Fg(color::Rgb(255, 255, 255)), Bg(color::Rgb(240, 173, 78)), style::Reset).to_string()
+}
+
+pub fn ce() -> String {
+    format!("{}{} CE {}", Fg(color::Rgb(255, 255, 255)), Bg(color::Rgb(240, 173, 78)), style::Reset).to_string()
+}
+
+pub fn tle() -> String {
+    format!("{}{} TLE {}", Fg(color::Rgb(255, 255, 255)), Bg(color::Rgb(240, 173, 78)), style::Reset).to_string()
 }

--- a/src/subcommand/init.rs
+++ b/src/subcommand/init.rs
@@ -75,7 +75,7 @@ pub fn run(matches: &ArgMatches) {
             6 // 指定されていないならA〜F作成
         };
         if total_file <= 0 {
-            println!("{}: TOTAL_TASK can not set", colortext::WARNING);
+            println!("{}: TOTAL_TASK can not set", colortext::warning());
         }
         let files = (b'A'..=b'Z')
             .take(total_file as usize)

--- a/src/subcommand/submit.rs
+++ b/src/subcommand/submit.rs
@@ -10,16 +10,16 @@ pub const USAGE: &str ="acc submit [<CONTEST_NAME>] [<CONTEST_TASK_NAME] <FILE_N
 
     --- arg -------------------------------------------
       <CONTEST_NAME> <CONTEST_TASK_NAME> <FILE_NAME>
-          Specify all
-          ex.) $ acc submit practice practice_1 p1(.cpp)
+        Specify all.
+        ex.) $ acc submit practice practice_1 p1(.cpp)
 
       <CONTEST_NAME> <FILE_NAME>
-          CONTEST_TASK_NAME and FILE_NAME are the same.
-          ex.) $ acc submit practice practice_1(.cpp)
+        CONTEST_TASK_NAME and FILE_NAME are the same.
+        ex.) $ acc submit practice practice_1(.cpp)
 
       <FILE_NAME>
-          Use settings in config.toml
-          ex.) $ acc submit 1(.cpp)
+        Use settings in config.toml and specify the FILE_NAME as task name.
+        ex.) $ acc submit 1(.cpp)
     ---------------------------------------------------
 
 ";

--- a/src/subcommand/submit.rs
+++ b/src/subcommand/submit.rs
@@ -5,10 +5,33 @@ use std::{env, process};
 
 pub const NAME: &str = "submit";
 
+pub const USAGE: &str ="acc submit [<CONTEST_NAME>] [<CONTEST_TASK_NAME] <FILE_NAME>
+
+    --- arg -------------------------------------------
+      <CONTEST_NAME> <CONTEST_TASK_NAME> <FILE_NAME>
+          Specify all
+          ex.) $ acc submit practice practice_1 p1(.cpp)
+
+      <CONTEST_NAME> <FILE_NAME>
+          CONTEST_TASK_NAME and FILE_NAME are the same.
+          ex.) $ acc submit practice practice_1(.cpp)
+
+      <FILE_NAME>
+          Use settings in config.toml
+          ex.) $ acc submit 1(.cpp)
+    ---------------------------------------------------
+
+";
+
 pub fn get_command<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name(&NAME)
         .about("Submits source code to AtCoder")
-        .arg(Arg::with_name("TASK_NAME").required(true).index(1))
+        .usage(USAGE)
+        .arg(
+            Arg::with_name("CONTEST_INFO")
+            .required(true)
+            .max_values(3)
+        )
 }
 
 fn get_source(file_name: &str) -> Option<String> {
@@ -22,10 +45,25 @@ fn get_source(file_name: &str) -> Option<String> {
 }
 
 pub fn run(matches: &ArgMatches) {
-    let task_name = matches.value_of("TASK_NAME").unwrap();
+    let contest_info: Vec<&str> = matches.values_of("CONTEST_INFO").unwrap().collect();
     let config = util::load_config(true);
-    let contest_name = config.contest;
-    let contest_task_name = config.contest_task_name;
+
+    let (contest_name, contest_task_name, task_name) = match contest_info.len() {
+        1 => {
+            let task_name = contest_info[0];
+            let contest_task_name = config.contest_task_name.unwrap_or(config.contest.clone()) + "_" + &util::remove_extension(task_name).to_lowercase();
+            (config.contest, contest_task_name, task_name)
+        },
+        2 => {
+            let contest_task_name = util::remove_extension(contest_info[1]);
+            (contest_info[0].to_string(), contest_task_name, contest_info[1])
+        },
+        _ => {
+            let contest_task_name = util::remove_extension(contest_info[1]);
+            (contest_info[0].to_string(), contest_task_name, contest_info[2])
+        },
+    };
+
     let language = if util::has_extension(task_name) {
         let extension = task_name.clone().split_terminator(".").last().unwrap();
         util::select_language(config.languages, &extension).unwrap()
@@ -39,49 +77,45 @@ pub fn run(matches: &ArgMatches) {
             process::exit(1);
         }).clone()
     };
+
     let extension = language.extension;
-    let (file_name, task_name) = if util::has_extension(task_name) {
-        let extension = String::from(".") + &extension;
-        (task_name.to_string(), task_name.strip_suffix(&extension).unwrap())
+    let file_name = if util::has_extension(task_name) {
+        task_name.to_string()
     } else {
-        ([task_name, &extension].join("."), task_name)
+        [task_name, &extension].join(".")
     };
     let language_id = language.language_id;
 
     let client = AccClient::new(true);
     let url = acc_client::SUBMIT_URL.to_string();
     let url = url.replace("<CONTEST>", &contest_name);
-    let task = if let Some(contest_task_name) = contest_task_name {
-        contest_task_name
-    } else {
-        contest_name.clone()
-    };
     let source = get_source(&file_name).unwrap_or_else(|| {
         util::print_error(format!("{} is not found", &file_name));
         process::exit(1);
     });
-    let screen_name = format!("{}_{}", &task, task_name.to_lowercase());
     let token = client.get_csrf_token().unwrap_or_else(|| {
         util::print_error("Require to run \"acc login\"");
         process::exit(1);
     });
+    println!("{}", &contest_task_name);
     let form_data = vec![
         ("csrf_token", token.clone()),
         ("sourceCode", source),
         ("data.LanguageId", language_id.to_string()),
-        ("data.TaskScreenName", screen_name),
+        ("data.TaskScreenName", contest_task_name),
     ];
     let result = client.post_form_data(&url, form_data);
-    if result.is_some() {
-        let (url, _, cookies) = result.unwrap();
-        let correct_url = acc_client::SUBMISSIONS_URL.replace("<CONTEST>", &contest_name);
-        util::save_state(&token, cookies);
-        if &correct_url == &url { // submit後は自分の提出のページに遷移することを利用
-            println!("OK");
-        } else {
-            util::print_error("failed to submit source code");
-        }
-    } else {
-        util::print_error("failed to get submit page");
+    match result {
+        Some(result) => {
+            let (url, _content, cookies) = result;
+            let correct_url = acc_client::SUBMISSIONS_URL.replace("<CONTEST>", &contest_name);
+            util::save_state(&token, cookies);
+            if &correct_url == &url { // submit後は自分の提出のページに遷移することを利用
+                println!("OK");
+            } else {
+                util::print_error("failed to submit source code");
+            }
+        },
+        None => util::print_error("failed to get submit page")
     }
 }

--- a/src/subcommand/test.rs
+++ b/src/subcommand/test.rs
@@ -61,10 +61,10 @@ impl PartialEq for Status {
 impl Status {
     fn to_string(&self) -> String {
         match self {
-            Status::AC => colortext::AC.to_string(),
-            Status::TLE => colortext::TLE.to_string(),
-            Status::RE => colortext::RE.to_string(),
-            Status::WA => colortext::WA.to_string(),
+            Status::AC => colortext::ac(),
+            Status::TLE => colortext::tle(),
+            Status::RE => colortext::re(),
+            Status::WA => colortext::wa(),
         }
     }
 }
@@ -116,7 +116,7 @@ fn compile(config: &Test, task_name: &str) -> bool {
         util::print_error("compile_arg in config.toml is not defined");
         return false;
     }
-    println!("{}: starting compile", colortext::INFO);
+    println!("{}: starting compile", colortext::info());
     let arg = config.compile_arg.as_ref().unwrap();
     let arg = arg.replace("<TASK>", task_name);
     let args = arg.split(" ");
@@ -131,10 +131,10 @@ fn compile(config: &Test, task_name: &str) -> bool {
     if !status.success() {
         let output = String::from_utf8_lossy(&output.stderr);
         util::print_error("failed to compile");
-        println!("{}\n\nresult: {}", output, colortext::CE);
+        println!("{}\n\nresult: {}", output, colortext::ce());
         return false;
     }
-    println!("{}: compiled successfully\n", colortext::INFO);
+    println!("{}: compiled successfully\n", colortext::info());
     return true;
 }
 
@@ -219,7 +219,7 @@ pub fn get_testcases(
     let url = acc_client::TASK_URL.to_string();
     let url = url.replace("<CONTEST>", &contest_name);
     let url = url.replace("<CONTEST_TASK>", &contest_task_name);
-    println!("{}: get testcase in \"{}\"", colortext::INFO, &url);
+    println!("{}: get testcase in \"{}\"", colortext::info(), &url);
     let result = client.get_page(&url).unwrap_or_else(|| {
         util::print_error("The correct test case could not be get");
         process::exit(1);
@@ -266,7 +266,7 @@ pub fn test(task_name: &str, inputs: &Vec<String>, outputs: &Vec<String>, config
             return;
         }
     }
-    println!("{}: starting test ...", colortext::INFO);
+    println!("{}: starting test ...", colortext::info());
     for (input, output) in inputs.iter().zip(outputs.iter()) {
         count += 1;
         print!("- testcase {} ... ", count);
@@ -275,21 +275,21 @@ pub fn test(task_name: &str, inputs: &Vec<String>, outputs: &Vec<String>, config
         let (caused_runtime_error, result) = execute(config, task_name, input, tle_time);
         if caused_runtime_error {
             all_result = all_result.max(Status::RE);
-            println!("{}", colortext::RE);
+            println!("{}", colortext::re());
             continue;
         }
         if result.is_none() { all_result = all_result.max(Status::TLE);
-            println!("{}", colortext::TLE);
+            println!("{}", colortext::tle());
             continue;
         }
         let result = util::remove_last_indent(result.unwrap());
         let output = util::remove_last_indent(output);
         let is_correct = result == output;
         let status = if is_correct {
-            colortext::AC
+            colortext::ac()
         } else {
             all_result = all_result.max(Status::WA);
-            colortext::WA
+            colortext::wa()
         };
         println!("{}", status);
         if !is_correct && needs_print {

--- a/src/subcommand/test.rs
+++ b/src/subcommand/test.rs
@@ -17,16 +17,16 @@ pub const USAGE: &str ="acc test [<CONTEST_NAME>] [<CONTEST_TASK_NAME] <FILE_NAM
 
     --- arg -------------------------------------------
       <CONTEST_NAME> <CONTEST_TASK_NAME> <FILE_NAME>
-          Specify all
-          ex.) $ acc test practice practice_1 p1(.cpp)
+        Specify all
+        ex.) $ acc test practice practice_1 p1(.cpp)
 
       <CONTEST_NAME> <FILE_NAME>
-          CONTEST_TASK_NAME and FILE_NAME are the same.
-          ex.) $ acc test practice practice_1(.cpp)
+        CONTEST_TASK_NAME and FILE_NAME are the same.
+        ex.) $ acc test practice practice_1(.cpp)
 
       <FILE_NAME>
-          Use settings in config.toml
-          ex.) $ acc test 1(.cpp)
+        Use settings in config.toml and specify the FILE_NAME as task name.
+        ex.) $ acc test 1(.cpp)
     ---------------------------------------------------
 
 ";

--- a/src/subcommand/watch.rs
+++ b/src/subcommand/watch.rs
@@ -1,25 +1,70 @@
 use crate::subcommand::test;
 use crate::util;
+use crate::colortext;
 use chrono::Local;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
-use std::sync::mpsc::channel;
+use termion::raw::IntoRawMode;
+use termion::event::{Event, Key, parse_event};
+use termion::async_stdin;
+use std::sync::mpsc::{channel, RecvTimeoutError};
 use std::time::Duration;
 use std::{env, process};
+use std::io::{Write, Read, stdout};
 
 pub const NAME: &str = "watch";
 
+pub const USAGE: &str ="acc watch [<CONTEST_NAME>] [<CONTEST_TASK_NAME] <FILE_NAME>
+
+    q: exit
+
+    --- arg -------------------------------------------
+      <CONTEST_NAME> <CONTEST_TASK_NAME> <FILE_NAME>
+          Specify all
+          ex.) $ acc watch practice practice_1 p1(.cpp)
+
+      <CONTEST_NAME> <FILE_NAME>
+          CONTEST_TASK_NAME and FILE_NAME are the same.
+          ex.) $ acc watch practice practice_1(.cpp)
+
+      <FILE_NAME>
+          Use settings in config.toml
+          ex.) $ acc watch 1(.cpp)
+    ---------------------------------------------------
+
+";
+
 pub fn get_command<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name(&NAME)
-        .about("Watch <TASK_NAME> modification")
-        .arg(Arg::with_name("TASK_NAME").required(true).index(1))
+        .about("Watch <FILE_NAME> modification")
+        .usage(USAGE)
+        .arg(
+            Arg::with_name("CONTEST_INFO")
+            .required(true)
+            .max_values(3)
+        )
 }
 
 pub fn run(matches: &ArgMatches) {
-    let task_name = matches.value_of("TASK_NAME").unwrap();
+    let contest_info: Vec<&str> = matches.values_of("CONTEST_INFO").unwrap().collect();
     let config = util::load_config(true);
-    let contest_task_name = config.contest_task_name;
-    let contest_name = config.contest;
+
+    let (contest_name, contest_task_name, task_name) = match contest_info.len() {
+        1 => {
+            let task_name = contest_info[0];
+            let contest_task_name = config.contest_task_name.unwrap_or(config.contest.clone()) + "_" + &util::remove_extension(task_name).to_lowercase();
+            (config.contest, contest_task_name, task_name)
+        },
+        2 => {
+            let contest_task_name = util::remove_extension(contest_info[1]);
+            (contest_info[0].to_string(), contest_task_name, contest_info[1])
+        },
+        _ => {
+            let contest_task_name = util::remove_extension(contest_info[1]);
+            (contest_info[0].to_string(), contest_task_name, contest_info[2])
+        },
+    };
+
     let language = if util::has_extension(task_name) {
         let extension = task_name.clone().split_terminator(".").last().unwrap();
         util::select_language(config.languages, &extension).unwrap()
@@ -36,15 +81,14 @@ pub fn run(matches: &ArgMatches) {
     let config = language.test;
     let extension = language.extension;
     let task_name = if util::has_extension(task_name) {
-        let extension = String::from(".") + &extension;
-        task_name.strip_suffix(&extension).unwrap()
+        util::remove_extension(task_name)
     } else {
-        task_name
+        task_name.to_string()
     };
-    let (inputs, outputs) = test::get_testcases(&contest_name, contest_task_name, &task_name);
+    let (inputs, outputs) = test::get_testcases(&contest_name, contest_task_name);
 
     let mut path = env::current_dir().unwrap();
-    let file_name = [task_name, &extension].join(".");
+    let file_name = [task_name.clone(), extension].join(".");
     path.push(file_name);
     let path = path.to_str().unwrap();
     let (tx, rx) = channel();
@@ -52,19 +96,39 @@ pub fn run(matches: &ArgMatches) {
     watcher.watch(path, RecursiveMode::NonRecursive).unwrap();
     println!("watching task {} ...", task_name);
     let mut count = 1;
+    let mut stdin = async_stdin().bytes();
+    let mut stdout = stdout().into_raw_mode().unwrap();
+    stdout.flush().unwrap();
     loop {
-        match rx.recv() {
+        match rx.recv_timeout(Duration::from_millis(10)) {
             Ok(event) => {
                 if let DebouncedEvent::Write(_) = event {
+                    stdout.suspend_raw_mode().unwrap();
                     println!("[{}]: {}", count, Local::now().format("%Y/%m/%d %H:%M:%S"));
                     test::test(&task_name, &inputs, &outputs, &config);
                     println!("\n");
+                    stdout.activate_raw_mode().unwrap();
                     count += 1;
                 }
-            }
-            Err(_e) => {
-                util::print_error("can not watch file modification");
-                process::exit(1);
+            },
+            Err(e) => {
+                if e == RecvTimeoutError::Timeout {
+                    let b = stdin.next();
+                    if let Some(k) = b {
+                        let k = parse_event(k.unwrap(), &mut stdin).unwrap_or(Event::Key(Key::Char('q')));
+                        match k {
+                            Event::Key(Key::Char('q')) | Event::Key(Key::Ctrl('c')) => {
+                                stdout.suspend_raw_mode().unwrap();
+                                println!("{}: finished", colortext::INFO);
+                                break;
+                            },
+                            _ => {}
+                        }
+                    }
+                } else {
+                    util::print_error("can not watch file modification");
+                    process::exit(1);
+                }
             }
         }
     }

--- a/src/subcommand/watch.rs
+++ b/src/subcommand/watch.rs
@@ -119,7 +119,7 @@ pub fn run(matches: &ArgMatches) {
                         match k {
                             Event::Key(Key::Char('q')) | Event::Key(Key::Ctrl('c')) => {
                                 stdout.suspend_raw_mode().unwrap();
-                                println!("{}: finished", colortext::INFO);
+                                println!("{}: finished", colortext::info());
                                 break;
                             },
                             _ => {}

--- a/src/subcommand/watch.rs
+++ b/src/subcommand/watch.rs
@@ -20,16 +20,16 @@ pub const USAGE: &str ="acc watch [<CONTEST_NAME>] [<CONTEST_TASK_NAME] <FILE_NA
 
     --- arg -------------------------------------------
       <CONTEST_NAME> <CONTEST_TASK_NAME> <FILE_NAME>
-          Specify all
-          ex.) $ acc watch practice practice_1 p1(.cpp)
+        Specify all
+        ex.) $ acc watch practice practice_1 p1(.cpp)
 
       <CONTEST_NAME> <FILE_NAME>
-          CONTEST_TASK_NAME and FILE_NAME are the same.
-          ex.) $ acc watch practice practice_1(.cpp)
+        CONTEST_TASK_NAME and FILE_NAME are the same.
+        ex.) $ acc watch practice practice_1(.cpp)
 
       <FILE_NAME>
-          Use settings in config.toml
-          ex.) $ acc watch 1(.cpp)
+        Use settings in config.toml and specify the FILE_NAME as task name.
+        ex.) $ acc watch 1(.cpp)
     ---------------------------------------------------
 
 ";

--- a/src/util.rs
+++ b/src/util.rs
@@ -57,6 +57,15 @@ pub fn has_extension<S: Into<String>>(task: S) -> bool {
     task.contains(".")
 }
 
+pub fn remove_extension<S:Into<String>>(file_name: S) -> String {
+    let file_name = file_name.into();
+    if !has_extension(&file_name) {
+        return file_name;
+    }
+    let extension = ".".to_string() + file_name.clone().split_terminator(".").last().unwrap();
+    file_name.strip_suffix(&extension).unwrap().to_string()
+}
+
 pub fn remove_last_indent<S: Into<String>>(content: S) -> String {
     let mut result = content.into();
     if result.ends_with("\n") {
@@ -115,7 +124,6 @@ pub fn select_language(languages: HashMap<String, Language>, extension: &str) ->
     print_content(&mut stdout, &mut down);
     for c in stdin.keys() {
         match c.unwrap() {
-            Key::Char('q') => break,
             Key::Char('j') | Key::Down  => down  = (down + 1) % count,
             Key::Char('k') | Key::Up    => down  = (count + down - 1) % count,
             Key::Char('\n') => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -37,12 +37,12 @@ print_wrong_answer = true
 
 pub fn print_error<S: Into<String>>(error_message: S) {
     let error_message = error_message.into();
-    println!("{}: {}", colortext::ERROR, error_message);
+    println!("{}: {}", colortext::error(), error_message);
 }
 
 pub fn print_warning<S: Into<String>>(warning_message: S) {
     let warning_message = warning_message.into();
-    println!("{}: {}", colortext::WARNING, warning_message);
+    println!("{}: {}", colortext::warning(), warning_message);
 }
 
 pub fn make_dir(dir_name: &str) -> bool {
@@ -165,7 +165,7 @@ pub fn load_config(is_local: bool) -> Config {
         let _ = make_dir(config_dir.to_str().unwrap());
         let mut file = fs::File::create(config_path).unwrap();
         file.write_all(DEFAULT_CONFIG.as_bytes()).unwrap();
-        println!("{}: {} is created", colortext::INFO, config_path);
+        println!("{}: {} is created", colortext::info(), config_path);
     }
 
     let content = read_file(config_path);


### PR DESCRIPTION
- [update] test, submit, watchコマンドでコンテスト情報を指定できるよう変更しヘルプを追記
- [update] color textをtermionを使ったものに変更
- [fix] 存在しないファイル，また設定にない拡張子を指定したときにエラーを表示するよう修正
- [update] READMEにtest, watch, submitの引数についての記述を追記
- [update] 各コマンドのヘルプを調整

close #26
close #21
